### PR TITLE
Park js-ipfs version to 0.33.1 because of breaking changes in 0.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -880,6 +880,11 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -1152,6 +1157,11 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
+    },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "after": {
       "version": "0.8.2",
@@ -4678,6 +4688,60 @@
         "secp256k1": "^3.0.1"
       }
     },
+    "ethers": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.21.tgz",
+      "integrity": "sha512-wKW0tG15n91qtnt6e1YUXOeRRiHc03U6qenmLQbjiPLX9KVhNnBKe1kFpRtiiuPp0dyHsWWmtML9pz44pmAO1g==",
+      "requires": {
+        "@types/node": "^10.3.2",
+        "aes-js": "3.0.0",
+        "bn.js": "^4.4.0",
+        "elliptic": "6.3.3",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
+      }
+    },
     "ethjs-util": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
@@ -5506,12 +5570,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5526,17 +5592,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5653,7 +5722,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5665,6 +5735,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5679,6 +5750,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5692,6 +5764,7 @@
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5790,7 +5863,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5802,6 +5876,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5923,6 +5998,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7891,17 +7967,46 @@
       }
     },
     "ipfs-log": {
-      "version": "github:orbitdb/ipfs-log#1d567b5c55bd0a326e653b7865c111fa424290c5",
+      "version": "github:orbitdb/ipfs-log#2117540ba078214383e6a4248c7162c201ae9224",
       "from": "github:orbitdb/ipfs-log",
       "requires": {
+        "cids": "^0.5.7",
+        "ipld-dag-pb": "^0.15.2",
         "orbit-db-identity-provider": "github:orbitdb/orbit-db-identity-provider#147b6ee1024a497d9ea34c6abe53e067ee4919a1",
         "p-map": "^1.1.1",
-        "p-whilst": "^1.0.0"
+        "p-whilst": "^1.0.0",
+        "pify": "^4.0.1"
       },
       "dependencies": {
+        "ipld-dag-pb": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.15.2.tgz",
+          "integrity": "sha512-9mzeYW4FneGROH+/PXMbXsfy3cUsMYHaI6vUu8nNpSTyQdGF+fa1ViA+jvqWzM8zXYwG4OOSCAAADssJeELAvw==",
+          "requires": {
+            "async": "^2.6.1",
+            "bs58": "^4.0.1",
+            "cids": "~0.5.4",
+            "class-is": "^1.1.0",
+            "is-ipfs": "~0.4.2",
+            "multihashing-async": "~0.5.1",
+            "protons": "^1.0.1",
+            "pull-stream": "^3.6.9",
+            "pull-traverse": "^1.0.3",
+            "stable": "~0.1.8"
+          }
+        },
         "orbit-db-identity-provider": {
           "version": "github:orbitdb/orbit-db-identity-provider#147b6ee1024a497d9ea34c6abe53e067ee4919a1",
-          "from": "github:orbitdb/orbit-db-identity-provider"
+          "from": "github:orbitdb/orbit-db-identity-provider",
+          "requires": {
+            "ethers": "^4.0.20",
+            "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#c5d0d9daa540b29cc9f5b662a9519a26e6b0289d"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
@@ -9428,9 +9533,12 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "ursa-optional": "~0.9.9"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -9605,9 +9713,12 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "ursa-optional": "~0.9.9"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -9715,9 +9826,12 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "ursa-optional": "~0.9.9"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -9896,8 +10010,7 @@
         "simple-peer": "^9.1.2",
         "socket.io": "^2.1.1",
         "socket.io-client": "^2.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
+        "stream-to-pull-stream": "^1.7.2"
       },
       "dependencies": {
         "multiaddr": {
@@ -9942,6 +10055,10 @@
               }
             }
           }
+        },
+        "webrtcsupport": {
+          "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
+          "from": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
         }
       }
     },
@@ -11718,34 +11835,6 @@
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
-    "orbit-db": {
-      "version": "git://github.com/orbitdb/orbit-db.git#0a121359cce43c9d209f3b3924fced780daf1dc2",
-      "from": "git://github.com/orbitdb/orbit-db.git#feat/new-acs",
-      "requires": {
-        "ipfs-pubsub-1on1": "~0.0.4",
-        "ipld-dag-pb": "0.14.11",
-        "localstorage-down": "^0.6.7",
-        "logplease": "^1.2.14",
-        "multihashes": "^0.4.12",
-        "orbit-db-access-controllers": "github:orbitdb/orbit-db-access-controllers#7809f2368c326dd2b82bf49545bee72bdb12a478",
-        "orbit-db-cache": "~0.2.4",
-        "orbit-db-counterstore": "github:orbitdb/orbit-db-counterstore#4c3dec872da616ec70e97bac86873a2f94e01e79",
-        "orbit-db-docstore": "github:orbitdb/orbit-db-docstore#e5ce14b503bd5633260e450c6a096f9ab6d8e4aa",
-        "orbit-db-eventstore": "github:orbitdb/orbit-db-eventstore#b217a83b57a66104c6eab96585d770c98b06b04f",
-        "orbit-db-feedstore": "github:orbitdb/orbit-db-feedstore#0a563d7c79acc8746969bb1ee486e6282414063c",
-        "orbit-db-identity-provider": "github:orbitdb/orbit-db-identity-provider#147b6ee1024a497d9ea34c6abe53e067ee4919a1",
-        "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#72d93ca18e2ff72d2e44100150309ff9d5c370ac",
-        "orbit-db-kvstore": "github:orbitdb/orbit-db-kvstore#32550cbb8733513a84149f35d6ea94de0c40691f",
-        "orbit-db-pubsub": "~0.5.5",
-        "orbit-db-store": "github:orbitdb/orbit-db-store#8842a31abe86e3b144294fe16c45a14fe0005f0c"
-      },
-      "dependencies": {
-        "orbit-db-identity-provider": {
-          "version": "github:orbitdb/orbit-db-identity-provider#147b6ee1024a497d9ea34c6abe53e067ee4919a1",
-          "from": "github:orbitdb/orbit-db-identity-provider"
-        }
-      }
-    },
     "orbit-db-access-controllers": {
       "version": "github:orbitdb/orbit-db-access-controllers#7809f2368c326dd2b82bf49545bee72bdb12a478",
       "from": "github:orbitdb/orbit-db-access-controllers",
@@ -11815,12 +11904,8 @@
         "orbit-db-eventstore": "github:orbitdb/orbit-db-eventstore#b217a83b57a66104c6eab96585d770c98b06b04f"
       }
     },
-    "orbit-db-identity-provider": {
-      "version": "git://github.com/orbitdb/orbit-db-identity-provider.git#147b6ee1024a497d9ea34c6abe53e067ee4919a1",
-      "from": "git://github.com/orbitdb/orbit-db-identity-provider.git#master"
-    },
     "orbit-db-keystore": {
-      "version": "github:orbitdb/orbit-db-keystore#72d93ca18e2ff72d2e44100150309ff9d5c370ac",
+      "version": "github:orbitdb/orbit-db-keystore#c5d0d9daa540b29cc9f5b662a9519a26e6b0289d",
       "from": "github:orbitdb/orbit-db-keystore",
       "requires": {
         "elliptic": "^6.4.0",
@@ -11850,7 +11935,7 @@
       "version": "github:orbitdb/orbit-db-store#8842a31abe86e3b144294fe16c45a14fe0005f0c",
       "from": "github:orbitdb/orbit-db-store",
       "requires": {
-        "ipfs-log": "github:orbitdb/ipfs-log#1d567b5c55bd0a326e653b7865c111fa424290c5",
+        "ipfs-log": "github:orbitdb/ipfs-log#2117540ba078214383e6a4248c7162c201ae9224",
         "logplease": "^1.2.14",
         "p-each-series": "^1.0.0",
         "readable-stream": "~2.3.5"
@@ -11876,10 +11961,51 @@
       "version": "git://github.com/orbitdb/orbit-core.git#9a439360965c9760382eacc9fd9e08b5cddf9d6f",
       "from": "git://github.com/orbitdb/orbit-core.git#dev/overall-refactor",
       "requires": {
-        "ipfs": "^0.33.1",
         "logplease": "~1.2.15",
-        "orbit-db": "git://github.com/orbitdb/orbit-db.git#0a121359cce43c9d209f3b3924fced780daf1dc2",
-        "orbit-db-identity-provider": "git://github.com/orbitdb/orbit-db-identity-provider.git#147b6ee1024a497d9ea34c6abe53e067ee4919a1"
+        "orbit-db": "github:orbitdb/orbit-db#0a121359cce43c9d209f3b3924fced780daf1dc2",
+        "orbit-db-identity-provider": "github:orbitdb/orbit-db-identity-provider#2dfbb69d83d1c829b4691ec2dbd8d12efedc117c"
+      },
+      "dependencies": {
+        "orbit-db": {
+          "version": "github:orbitdb/orbit-db#0a121359cce43c9d209f3b3924fced780daf1dc2",
+          "from": "github:orbitdb/orbit-db#feat/new-acs",
+          "requires": {
+            "ipfs-pubsub-1on1": "~0.0.4",
+            "ipld-dag-pb": "0.14.11",
+            "localstorage-down": "^0.6.7",
+            "logplease": "^1.2.14",
+            "multihashes": "^0.4.12",
+            "orbit-db-access-controllers": "github:orbitdb/orbit-db-access-controllers#7809f2368c326dd2b82bf49545bee72bdb12a478",
+            "orbit-db-cache": "~0.2.4",
+            "orbit-db-counterstore": "github:orbitdb/orbit-db-counterstore#4c3dec872da616ec70e97bac86873a2f94e01e79",
+            "orbit-db-docstore": "github:orbitdb/orbit-db-docstore#e5ce14b503bd5633260e450c6a096f9ab6d8e4aa",
+            "orbit-db-eventstore": "github:orbitdb/orbit-db-eventstore#b217a83b57a66104c6eab96585d770c98b06b04f",
+            "orbit-db-feedstore": "github:orbitdb/orbit-db-feedstore#0a563d7c79acc8746969bb1ee486e6282414063c",
+            "orbit-db-identity-provider": "github:orbitdb/orbit-db-identity-provider#8a102d3b34e4ff04a77626beedb645de08efe074",
+            "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#c5d0d9daa540b29cc9f5b662a9519a26e6b0289d",
+            "orbit-db-kvstore": "github:orbitdb/orbit-db-kvstore#32550cbb8733513a84149f35d6ea94de0c40691f",
+            "orbit-db-pubsub": "~0.5.5",
+            "orbit-db-store": "github:orbitdb/orbit-db-store#8842a31abe86e3b144294fe16c45a14fe0005f0c"
+          },
+          "dependencies": {
+            "orbit-db-identity-provider": {
+              "version": "github:orbitdb/orbit-db-identity-provider#8a102d3b34e4ff04a77626beedb645de08efe074",
+              "from": "github:orbitdb/orbit-db-identity-provider",
+              "requires": {
+                "ethers": "^4.0.20",
+                "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#c5d0d9daa540b29cc9f5b662a9519a26e6b0289d"
+              }
+            }
+          }
+        },
+        "orbit-db-identity-provider": {
+          "version": "github:orbitdb/orbit-db-identity-provider#2dfbb69d83d1c829b4691ec2dbd8d12efedc117c",
+          "from": "github:orbitdb/orbit-db-identity-provider#fix/devdeps-to-deps",
+          "requires": {
+            "ethers": "^4.0.20",
+            "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#c5d0d9daa540b29cc9f5b662a9519a26e6b0289d"
+          }
+        }
       }
     },
     "original": {
@@ -12304,9 +12430,12 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.9",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "ursa-optional": "~0.9.9"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -15355,6 +15484,11 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "scrypt-js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -17644,10 +17778,6 @@
         }
       }
     },
-    "webrtcsupport": {
-      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
-      "from": "github:ipfs/webrtcsupport"
-    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -17828,6 +17958,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "emoji-mart": "^2.9.1",
     "highlight.js": "^9.13.1",
     "i18next": "^12.0.0",
-    "ipfs": "^0.33.1",
+    "ipfs": "0.33.1",
     "mobx": "^5.5.2",
     "mobx-react": "^5.4.2",
     "orbit_": "git://github.com/orbitdb/orbit-core.git#dev/overall-refactor",


### PR DESCRIPTION
https://github.com/ipfs/js-ipfs/releases/tag/v0.34.0
Since we had ^0.33.1 as its version in package.json, a simple npm install breaks the build. Park the version for now until orbit-db supports the latest js-ipfs.